### PR TITLE
fix: use correct path for main script

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "cyclomatic-complexity",
   "description": "Tool for calculating cyclomatic complexity of a JavaScript and TypeScript code.",
   "version": "1.2.3",
-  "main": "./bin/index.js",
+  "main": "./bin/src/index.js",
   "repository": "https://github.com/pilotpirxie/cyclomatic-complexity.git",
   "author": "pilotpirxie <10637666+pilotpirxie@users.noreply.github.com>",
   "license": "MIT",


### PR DESCRIPTION
This resolves an import issue with trying to call cyclomatic-complexity from other TypeScript projects.